### PR TITLE
feat: RDF Turtle syntax validation (GOV-QUAL punto 1)

### DIFF
--- a/src/main/java/it/gov/innovazione/ndc/controller/ValidationController.java
+++ b/src/main/java/it/gov/innovazione/ndc/controller/ValidationController.java
@@ -1,6 +1,7 @@
 package it.gov.innovazione.ndc.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidationResult;
 import it.gov.innovazione.ndc.service.ValidationService;
 import it.gov.innovazione.ndc.validator.ValidationResultDto;
 import lombok.RequiredArgsConstructor;
@@ -26,5 +27,14 @@ public class ValidationController {
     public ResponseEntity<ValidationResultDto> validateFile(@RequestParam(value = "type") String assetType,
                                                             @RequestParam(value = "file") MultipartFile file) {
         return AppJsonResponse.ok(validationService.validate(file, assetType));
+    }
+
+    @PostMapping("/syntax")
+    @Operation(
+            operationId = "validateSyntax",
+            description = "Validate only the Turtle syntax of a .ttl file, without requiring a specific asset type",
+            summary = "Validate Turtle syntax")
+    public ResponseEntity<RdfSyntaxValidationResult> validateSyntax(@RequestParam(value = "file") MultipartFile file) {
+        return AppJsonResponse.ok(validationService.validateSyntax(file));
     }
 }

--- a/src/main/java/it/gov/innovazione/ndc/harvester/pathprocessors/BaseSemanticAssetPathProcessor.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/pathprocessors/BaseSemanticAssetPathProcessor.java
@@ -17,6 +17,8 @@ import it.gov.innovazione.ndc.harvester.model.SemanticAssetPath;
 import it.gov.innovazione.ndc.harvester.model.extractors.RightsHolderExtractor;
 import it.gov.innovazione.ndc.harvester.model.index.NodeSummary;
 import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidationResult;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.model.harvester.HarvesterRun;
 import it.gov.innovazione.ndc.repository.SemanticAssetMetadataRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepository;
@@ -34,6 +36,7 @@ import org.apache.jena.rdf.model.Resource;
 public abstract class BaseSemanticAssetPathProcessor<P extends SemanticAssetPath, M extends SemanticAssetModel> implements SemanticAssetPathProcessor<P> {
     private final TripleStoreRepository tripleStoreRepository;
     protected final SemanticAssetMetadataRepository metadataRepository;
+    private final RdfSyntaxValidator rdfSyntaxValidator;
 
     private static <M extends SemanticAssetModel> SemanticAssetMetadata tryExtractMetadata(M model) {
         try {
@@ -92,10 +95,43 @@ public abstract class BaseSemanticAssetPathProcessor<P extends SemanticAssetPath
         // maybe call super() in there, anyways.
     }
 
+    private void validateTurtleSyntax(P path) {
+        RdfSyntaxValidationResult result = rdfSyntaxValidator.validateTurtle(path.getTtlPath());
+
+        if (result.hasWarnings()) {
+            logSemanticWarn(LoggingContext.builder()
+                    .message("Turtle syntax warnings for " + path)
+                    .details(result.getWarningsSummary())
+                    .stage(HarvesterStage.SYNTAX_VALIDATION)
+                    .harvesterStatus(HarvesterRun.Status.RUNNING)
+                    .build());
+        }
+
+        if (result.hasErrors()) {
+            logSemanticError(LoggingContext.builder()
+                    .message("Turtle syntax validation failed for " + path)
+                    .details(result.getErrorsSummary())
+                    .stage(HarvesterStage.SYNTAX_VALIDATION)
+                    .harvesterStatus(HarvesterRun.Status.RUNNING)
+                    .build());
+            throw new SinglePathProcessingException(
+                    String.format("Turtle syntax validation failed for '%s': %s", path, result.getErrorsSummary()),
+                    false);
+        }
+
+        logSemanticInfo(LoggingContext.builder()
+                .message("Turtle syntax validation passed for " + path)
+                .stage(HarvesterStage.SYNTAX_VALIDATION)
+                .harvesterStatus(HarvesterRun.Status.RUNNING)
+                .build());
+    }
+
     @Override
     public HarvesterStatsHolder process(String repoUrl, P path) {
         try {
             log.info("Processing path {}", path);
+
+            validateTurtleSyntax(path);
 
             log.debug("Loading model from {}", path);
             M model = loadModel(path.getTtlPath(), repoUrl);

--- a/src/main/java/it/gov/innovazione/ndc/harvester/pathprocessors/ControlledVocabularyPathProcessor.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/pathprocessors/ControlledVocabularyPathProcessor.java
@@ -11,6 +11,7 @@ import it.gov.innovazione.ndc.harvester.model.HarvesterStatsHolder;
 import it.gov.innovazione.ndc.harvester.model.Instance;
 import it.gov.innovazione.ndc.harvester.model.SemanticAssetModelFactory;
 import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.model.harvester.HarvesterRun;
 import it.gov.innovazione.ndc.repository.SemanticAssetMetadataRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepository;
@@ -35,8 +36,9 @@ public class ControlledVocabularyPathProcessor extends BaseSemanticAssetPathProc
     public ControlledVocabularyPathProcessor(TripleStoreRepository tripleStoreRepository, SemanticAssetModelFactory modelFactory,
                                              CsvParser csvParser, VocabularyDataService vocabularyDataService,
                                              SemanticAssetMetadataRepository metadataRepository,
+                                             RdfSyntaxValidator rdfSyntaxValidator,
                                              @Value("${ndc.baseUrl}") String baseUrl) {
-        super(tripleStoreRepository, metadataRepository);
+        super(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
         this.modelFactory = modelFactory;
         this.csvParser = csvParser;
         this.vocabularyDataService = vocabularyDataService;

--- a/src/main/java/it/gov/innovazione/ndc/harvester/pathprocessors/OntologyPathProcessor.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/pathprocessors/OntologyPathProcessor.java
@@ -3,6 +3,7 @@ package it.gov.innovazione.ndc.harvester.pathprocessors;
 import it.gov.innovazione.ndc.harvester.model.OntologyModel;
 import it.gov.innovazione.ndc.harvester.model.SemanticAssetModelFactory;
 import it.gov.innovazione.ndc.harvester.model.SemanticAssetPath;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.repository.SemanticAssetMetadataRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -14,8 +15,9 @@ public class OntologyPathProcessor extends BaseSemanticAssetPathProcessor<Semant
     private final SemanticAssetModelFactory modelFactory;
 
     public OntologyPathProcessor(TripleStoreRepository tripleStoreRepository, SemanticAssetModelFactory modelFactory,
-                                 SemanticAssetMetadataRepository metadataRepository) {
-        super(tripleStoreRepository, metadataRepository);
+                                 SemanticAssetMetadataRepository metadataRepository,
+                                 RdfSyntaxValidator rdfSyntaxValidator) {
+        super(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
         this.modelFactory = modelFactory;
     }
 

--- a/src/main/java/it/gov/innovazione/ndc/harvester/pathprocessors/SchemaPathProcessor.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/pathprocessors/SchemaPathProcessor.java
@@ -3,6 +3,7 @@ package it.gov.innovazione.ndc.harvester.pathprocessors;
 import it.gov.innovazione.ndc.harvester.model.SchemaModel;
 import it.gov.innovazione.ndc.harvester.model.SemanticAssetModelFactory;
 import it.gov.innovazione.ndc.harvester.model.SemanticAssetPath;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.repository.SemanticAssetMetadataRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -17,8 +18,9 @@ public class SchemaPathProcessor
 
     public SchemaPathProcessor(TripleStoreRepository tripleStoreRepository,
                                SemanticAssetModelFactory modelFactory,
-                               SemanticAssetMetadataRepository metadataRepository) {
-        super(tripleStoreRepository, metadataRepository);
+                               SemanticAssetMetadataRepository metadataRepository,
+                               RdfSyntaxValidator rdfSyntaxValidator) {
+        super(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
         this.modelFactory = modelFactory;
     }
 

--- a/src/main/java/it/gov/innovazione/ndc/harvester/validation/RdfSyntaxValidationResult.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/validation/RdfSyntaxValidationResult.java
@@ -1,0 +1,58 @@
+package it.gov.innovazione.ndc.harvester.validation;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@Builder
+public class RdfSyntaxValidationResult {
+
+    @Singular
+    private final List<Issue> errors;
+    @Singular
+    private final List<Issue> warnings;
+
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+
+    public boolean hasWarnings() {
+        return !warnings.isEmpty();
+    }
+
+    public boolean isValid() {
+        return !hasErrors();
+    }
+
+    public String getErrorsSummary() {
+        return errors.stream()
+                .map(Issue::toString)
+                .collect(Collectors.joining("; "));
+    }
+
+    public String getWarningsSummary() {
+        return warnings.stream()
+                .map(Issue::toString)
+                .collect(Collectors.joining("; "));
+    }
+
+    @Data
+    @Builder
+    public static class Issue {
+        private final long line;
+        private final long col;
+        private final String message;
+
+        @Override
+        public String toString() {
+            if (line > 0 && col > 0) {
+                return String.format("[line %d, col %d] %s", line, col, message);
+            }
+            return message;
+        }
+    }
+}

--- a/src/main/java/it/gov/innovazione/ndc/harvester/validation/RdfSyntaxValidator.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/validation/RdfSyntaxValidator.java
@@ -1,0 +1,98 @@
+package it.gov.innovazione.ndc.harvester.validation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.system.ErrorHandler;
+import org.apache.jena.riot.system.StreamRDFLib;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Component
+public class RdfSyntaxValidator {
+
+    public RdfSyntaxValidationResult validateTurtle(String filePath) {
+        log.debug("Validating Turtle syntax for {}", filePath);
+        CollectingErrorHandler errorHandler = new CollectingErrorHandler();
+        try {
+            RDFParser.source(filePath)
+                    .lang(Lang.TURTLE)
+                    .errorHandler(errorHandler)
+                    .checking(true)
+                    .parse(StreamRDFLib.sinkNull());
+        } catch (Exception e) {
+            if (errorHandler.errors.isEmpty()) {
+                errorHandler.errors.add(
+                        RdfSyntaxValidationResult.Issue.builder()
+                                .message(e.getMessage())
+                                .build());
+            }
+        }
+
+        RdfSyntaxValidationResult result = RdfSyntaxValidationResult.builder()
+                .errors(errorHandler.errors)
+                .warnings(errorHandler.warnings)
+                .build();
+
+        if (result.hasErrors()) {
+            log.debug("Turtle syntax validation FAILED for {}: {} error(s), {} warning(s)",
+                    filePath, result.getErrors().size(), result.getWarnings().size());
+        } else {
+            log.debug("Turtle syntax validation OK for {} ({} warning(s))",
+                    filePath, result.getWarnings().size());
+        }
+        return result;
+    }
+
+    private static class CollectingErrorHandler implements ErrorHandler {
+
+        private final List<RdfSyntaxValidationResult.Issue> errors = new ArrayList<>();
+        private final List<RdfSyntaxValidationResult.Issue> warnings = new ArrayList<>();
+
+        @Override
+        public void warning(String message, long line, long col) {
+            warnings.add(RdfSyntaxValidationResult.Issue.builder()
+                    .line(line)
+                    .col(col)
+                    .message(message)
+                    .build());
+        }
+
+        @Override
+        public void error(String message, long line, long col) {
+            errors.add(RdfSyntaxValidationResult.Issue.builder()
+                    .line(line)
+                    .col(col)
+                    .message(message)
+                    .build());
+        }
+
+        @Override
+        public void fatal(String message, long line, long col) {
+            errors.add(RdfSyntaxValidationResult.Issue.builder()
+                    .line(line)
+                    .col(col)
+                    .message(message)
+                    .build());
+            throw new RdfSyntaxFatalException(message, line, col);
+        }
+
+        public List<RdfSyntaxValidationResult.Issue> getErrors() {
+            return Collections.unmodifiableList(errors);
+        }
+
+        public List<RdfSyntaxValidationResult.Issue> getWarnings() {
+            return Collections.unmodifiableList(warnings);
+        }
+    }
+
+    static class RdfSyntaxFatalException extends RuntimeException {
+        RdfSyntaxFatalException(String message, long line, long col) {
+            super(String.format("[line %d, col %d] %s", line, col, message));
+        }
+    }
+}

--- a/src/main/java/it/gov/innovazione/ndc/service/ValidationService.java
+++ b/src/main/java/it/gov/innovazione/ndc/service/ValidationService.java
@@ -4,6 +4,8 @@ import it.gov.innovazione.ndc.controller.exception.InvalidFileException;
 import it.gov.innovazione.ndc.controller.exception.InvalidSemanticAssetException;
 import it.gov.innovazione.ndc.controller.exception.SemanticAssetGenericErrorException;
 import it.gov.innovazione.ndc.harvester.model.SemanticAssetModelValidationContext;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidationResult;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.validator.SemanticAssetValidator;
 import it.gov.innovazione.ndc.validator.ValidationResultDto;
 import it.gov.innovazione.ndc.validator.model.ValidationOutcome;
@@ -20,6 +22,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,6 +35,7 @@ public class ValidationService {
     private static final String FILE_CONTENT_TYPE = "text/turtle";
 
     private final List<SemanticAssetValidator> semanticAssetValidators;
+    private final RdfSyntaxValidator rdfSyntaxValidator;
 
     public ValidationResultDto validate(MultipartFile file, String assetType) {
 
@@ -55,6 +60,22 @@ public class ValidationService {
                     SemanticAssetModelValidationContext.builder()
                             .errors(List.of(new ValidationOutcome(null, e.getMessage(), e)))
                             .build());
+        }
+    }
+
+    public RdfSyntaxValidationResult validateSyntax(MultipartFile file) {
+        assertContentType(file);
+        try {
+            Path tempFile = Files.createTempFile("syntax-check-", ".ttl");
+            try {
+                file.transferTo(tempFile);
+                return rdfSyntaxValidator.validateTurtle(tempFile.toString());
+            } finally {
+                Files.deleteIfExists(tempFile);
+            }
+        } catch (IOException e) {
+            log.error("Error during syntax validation", e);
+            throw new SemanticAssetGenericErrorException();
         }
     }
 

--- a/src/main/java/it/gov/innovazione/ndc/service/logging/HarvesterStage.java
+++ b/src/main/java/it/gov/innovazione/ndc/service/logging/HarvesterStage.java
@@ -7,5 +7,6 @@ public enum HarvesterStage {
     CLEANING_VIRTUOSO,
     CLEANING_METADATA,
     PATH_SCANNING,
+    SYNTAX_VALIDATION,
     PROCESS_RESOURCE
 }

--- a/src/test/java/it/gov/innovazione/ndc/harvester/pathprocessors/ControlledVocabularyPathProcessorTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/pathprocessors/ControlledVocabularyPathProcessorTest.java
@@ -9,6 +9,8 @@ import it.gov.innovazione.ndc.harvester.model.SemanticAssetModelFactory;
 import it.gov.innovazione.ndc.harvester.model.index.RightsHolder;
 import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
 import it.gov.innovazione.ndc.harvester.service.SemanticContentStatsService;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidationResult;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.repository.SemanticAssetMetadataRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepository;
 import it.gov.innovazione.ndc.service.VocabularyDataService;
@@ -24,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -48,6 +51,8 @@ class ControlledVocabularyPathProcessorTest {
     @Mock
     SemanticContentStatsService semanticContentStatsService;
     @Mock
+    RdfSyntaxValidator rdfSyntaxValidator;
+    @Mock
     Model jenaModel;
 
     String baseUrl = "http://ndc";
@@ -57,7 +62,7 @@ class ControlledVocabularyPathProcessorTest {
     @BeforeEach
     void setup() {
         pathProcessor = new ControlledVocabularyPathProcessor(tripleStoreRepository, semanticAssetModelFactory,
-                csvParser, vocabularyDataService, metadataRepository, baseUrl);
+                csvParser, vocabularyDataService, metadataRepository, rdfSyntaxValidator, baseUrl);
     }
 
     @Test
@@ -66,6 +71,7 @@ class ControlledVocabularyPathProcessorTest {
         String csvFile = "cities.csv";
         CvPath path = CvPath.of(ttlFile, csvFile);
 
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(RdfSyntaxValidationResult.builder().build());
         when(semanticAssetModelFactory.createControlledVocabulary(ttlFile, "some-repo")).thenReturn(cvModel);
         when(cvModel.getRdfModel()).thenReturn(jenaModel);
         when(cvModel.getKeyConcept()).thenReturn("keyConcept");
@@ -91,6 +97,7 @@ class ControlledVocabularyPathProcessorTest {
         String ttlFile = "cities.ttl";
         CvPath path = CvPath.of(ttlFile, null);
 
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(RdfSyntaxValidationResult.builder().build());
         when(semanticAssetModelFactory.createControlledVocabulary(ttlFile, "some-repo")).thenReturn(cvModel);
         when(cvModel.getRdfModel()).thenReturn(jenaModel);
         SemanticAssetMetadata metadata = SemanticAssetMetadata.builder().build();

--- a/src/test/java/it/gov/innovazione/ndc/harvester/pathprocessors/OntologyPathProcessorTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/pathprocessors/OntologyPathProcessorTest.java
@@ -5,6 +5,8 @@ import it.gov.innovazione.ndc.harvester.model.SemanticAssetModelFactory;
 import it.gov.innovazione.ndc.harvester.model.SemanticAssetPath;
 import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
 import it.gov.innovazione.ndc.harvester.service.SemanticContentStatsService;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidationResult;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.repository.SemanticAssetMetadataRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepository;
 import org.apache.jena.rdf.model.Resource;
@@ -14,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,6 +35,8 @@ class OntologyPathProcessorTest {
     SemanticContentStatsService semanticContentStatsService;
     @Mock
     SemanticAssetMetadataRepository metadataRepository;
+    @Mock
+    RdfSyntaxValidator rdfSyntaxValidator;
 
     @InjectMocks
     OntologyPathProcessor pathProcessor;
@@ -41,6 +46,7 @@ class OntologyPathProcessorTest {
         String ttlFile = "cities.ttl";
         SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
 
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(RdfSyntaxValidationResult.builder().build());
         when(modelFactory.createOntology(ttlFile, "some-repo")).thenReturn(ontologyModel);
         when(ontologyModel.getMainResource()).thenReturn(ontology);
         SemanticAssetMetadata metadata = SemanticAssetMetadata.builder().build();

--- a/src/test/java/it/gov/innovazione/ndc/harvester/pathprocessors/SchemaPathProcessorTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/pathprocessors/SchemaPathProcessorTest.java
@@ -5,6 +5,8 @@ import it.gov.innovazione.ndc.harvester.model.SemanticAssetModelFactory;
 import it.gov.innovazione.ndc.harvester.model.SemanticAssetPath;
 import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
 import it.gov.innovazione.ndc.harvester.service.SemanticContentStatsService;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidationResult;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.repository.SemanticAssetMetadataRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepository;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -33,6 +35,8 @@ class SchemaPathProcessorTest {
     TripleStoreRepository repository;
     @Mock
     SemanticContentStatsService semanticContentStatsService;
+    @Mock
+    RdfSyntaxValidator rdfSyntaxValidator;
     @InjectMocks
     SchemaPathProcessor schemaPathProcessor;
 
@@ -52,6 +56,7 @@ class SchemaPathProcessorTest {
         String ttlFile = "index.ttl";
         SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
 
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(RdfSyntaxValidationResult.builder().build());
         when(modelFactory.createSchema(ttlFile, "some-repo")).thenReturn(schemaModel);
         when(schemaModel.getMainResource()).thenReturn(
             ResourceFactory.createResource("http://example.com/schema"));

--- a/src/test/java/it/gov/innovazione/ndc/harvester/pathprocessors/SemanticAssetPathProcessorTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/pathprocessors/SemanticAssetPathProcessorTest.java
@@ -6,6 +6,8 @@ import it.gov.innovazione.ndc.harvester.model.SemanticAssetPath;
 import it.gov.innovazione.ndc.harvester.model.exception.InvalidModelException;
 import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
 import it.gov.innovazione.ndc.harvester.service.SemanticContentStatsService;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidationResult;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.repository.SemanticAssetMetadataRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepository;
 import it.gov.innovazione.ndc.repository.TripleStoreRepositoryException;
@@ -18,9 +20,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -33,8 +37,9 @@ class SemanticAssetPathProcessorTest {
     private class TestSemanticAssetPathProcessor
         extends BaseSemanticAssetPathProcessor<SemanticAssetPath, OntologyModel> {
         public TestSemanticAssetPathProcessor(TripleStoreRepository tripleStoreRepository,
-                                              SemanticAssetMetadataRepository metadataRepository) {
-            super(tripleStoreRepository, metadataRepository);
+                                              SemanticAssetMetadataRepository metadataRepository,
+                                              RdfSyntaxValidator rdfSyntaxValidator) {
+            super(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
         }
 
         @Override
@@ -55,20 +60,26 @@ class SemanticAssetPathProcessorTest {
     @Mock
     private SemanticAssetMetadataRepository metadataRepository;
     @Mock
+    private RdfSyntaxValidator rdfSyntaxValidator;
+    @Mock
     private Model model;
     @Mock
     SemanticContentStatsService semanticContentStatsService;
     @Mock
     private Consumer<OntologyModel> modelEnricher;
 
+    private static final RdfSyntaxValidationResult VALID_RESULT =
+            RdfSyntaxValidationResult.builder().build();
+
     @Test
     void processingGoesThroughTwoCommonSteps() {
         final String repoUrl = "https://github.com/italia/daf-ontologie-vocabolari-controllati";
         String ttlFile = "somefile.ttl";
         TestSemanticAssetPathProcessor processor =
-            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository);
+            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
         SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
         SemanticAssetMetadata metadata = SemanticAssetMetadata.builder().build();
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(VALID_RESULT);
         when(modelDecorator.getRdfModel()).thenReturn(model);
         when(modelDecorator.extractMetadata()).thenReturn(metadata);
 
@@ -87,9 +98,10 @@ class SemanticAssetPathProcessorTest {
         final String repoUrl = "https://github.com/italia/daf-ontologie-vocabolari-controllati";
         String ttlFile = "somefile.ttl";
         TestSemanticAssetPathProcessor processor =
-            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository);
+            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
         SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
         SemanticAssetMetadata metadata = SemanticAssetMetadata.builder().build();
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(VALID_RESULT);
         when(modelDecorator.getRdfModel()).thenReturn(model);
         TripleStoreRepositoryException repositoryException =
             new TripleStoreRepositoryException("Oops!");
@@ -109,8 +121,9 @@ class SemanticAssetPathProcessorTest {
         final String repoUrl = "https://github.com/italia/daf-ontologie-vocabolari-controllati";
         String ttlFile = "somefile.ttl";
         TestSemanticAssetPathProcessor processor =
-            spy(new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository));
+            spy(new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository, rdfSyntaxValidator));
         SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(VALID_RESULT);
         InvalidModelException invalidModelException =
             new InvalidModelException("Cannot load model", new RuntimeException("Malformed TTL"));
         when(processor.loadModel(ttlFile, repoUrl)).thenThrow(invalidModelException);
@@ -128,8 +141,9 @@ class SemanticAssetPathProcessorTest {
         final String repoUrl = "https://github.com/italia/daf-ontologie-vocabolari-controllati";
         String ttlFile = "somefile.ttl";
         TestSemanticAssetPathProcessor processor =
-            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository);
+            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
         SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(VALID_RESULT);
         InvalidModelException invalidModelException =
             new InvalidModelException("Cannot find main resource");
         when(modelDecorator.getMainResource()).thenThrow(invalidModelException);
@@ -147,8 +161,9 @@ class SemanticAssetPathProcessorTest {
         final String repoUrl = "https://github.com/italia/daf-ontologie-vocabolari-controllati";
         String ttlFile = "somefile.ttl";
         TestSemanticAssetPathProcessor processor =
-            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository);
+            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
         SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(VALID_RESULT);
         RuntimeException enrichmentException =
             new RuntimeException("Something went wrong calculating enrichments");
         doThrow(enrichmentException).when(modelEnricher).accept(modelDecorator);
@@ -159,5 +174,58 @@ class SemanticAssetPathProcessorTest {
 
         verifyNoInteractions(tripleStoreRepository);
         verifyNoInteractions(metadataRepository);
+    }
+
+    @Test
+    void ifSyntaxValidationFailsShouldStopProcessingAndPropagate() {
+        final String repoUrl = "https://github.com/italia/daf-ontologie-vocabolari-controllati";
+        String ttlFile = "somefile.ttl";
+        TestSemanticAssetPathProcessor processor =
+            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
+        SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
+
+        RdfSyntaxValidationResult failedResult = RdfSyntaxValidationResult.builder()
+                .error(RdfSyntaxValidationResult.Issue.builder()
+                        .line(5).col(10)
+                        .message("Expected '.' or '}', got KEYWORD")
+                        .build())
+                .build();
+        when(rdfSyntaxValidator.validateTurtle(ttlFile)).thenReturn(failedResult);
+
+        assertThatThrownBy(() -> processor.process(repoUrl, path))
+            .isInstanceOf(SinglePathProcessingException.class)
+            .has(new Condition<>(e -> !((SinglePathProcessingException) e).isFatal(), "is not fatal"))
+            .cause()
+            .isInstanceOf(SinglePathProcessingException.class)
+            .hasMessageContaining("Turtle syntax validation failed")
+            .hasMessageContaining("Expected '.' or '}', got KEYWORD");
+
+        verifyNoInteractions(tripleStoreRepository);
+        verifyNoInteractions(metadataRepository);
+    }
+
+    @Test
+    void ifSyntaxValidationPassesWithWarningsProcessingShouldContinue() {
+        final String repoUrl = "https://github.com/italia/daf-ontologie-vocabolari-controllati";
+        String ttlFile = "somefile.ttl";
+        TestSemanticAssetPathProcessor processor =
+            new TestSemanticAssetPathProcessor(tripleStoreRepository, metadataRepository, rdfSyntaxValidator);
+        SemanticAssetPath path = SemanticAssetPath.of(ttlFile);
+        SemanticAssetMetadata metadata = SemanticAssetMetadata.builder().build();
+
+        RdfSyntaxValidationResult warningResult = RdfSyntaxValidationResult.builder()
+                .warning(RdfSyntaxValidationResult.Issue.builder()
+                        .line(3).col(1)
+                        .message("Prefix 'ex' is unused")
+                        .build())
+                .build();
+        when(rdfSyntaxValidator.validateTurtle(ttlFile)).thenReturn(warningResult);
+        when(modelDecorator.getRdfModel()).thenReturn(model);
+        when(modelDecorator.extractMetadata()).thenReturn(metadata);
+
+        processor.process(repoUrl, path);
+
+        verify(metadataRepository).save(metadata);
+        verify(tripleStoreRepository).save(repoUrl, model);
     }
 }

--- a/src/test/java/it/gov/innovazione/ndc/harvester/validation/RdfSyntaxValidatorDemoTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/validation/RdfSyntaxValidatorDemoTest.java
@@ -1,0 +1,199 @@
+package it.gov.innovazione.ndc.harvester.validation;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Demo test per GOV-QUAL: Validazione Sintattica RDF (Turtle).
+ *
+ * <p>Esegui con:
+ *   ./gradlew test --tests "*.RdfSyntaxValidatorDemoTest" --info
+ *
+ * <p>Usa i file TTL di esempio in src/test/resources/demo-sample-ttl/
+ * (copia di backlog/GOV-QUAL/demo/sample-ttl/)
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class RdfSyntaxValidatorDemoTest {
+
+    private static final String SAMPLE_RESOURCE_DIR = "demo-sample-ttl";
+    private static RdfSyntaxValidator validator;
+
+    @BeforeAll
+    static void setup() {
+        validator = new RdfSyntaxValidator();
+        System.out.println();
+        System.out.println("=".repeat(80));
+        System.out.println("  GOV-QUAL DEMO: Validazione Sintattica Turtle (pre-harvesting)");
+        System.out.println("=".repeat(80));
+        System.out.println();
+    }
+
+    @Test
+    @Order(1)
+    void demo_01_fileValido() {
+        Path file = resolve("valid-ontology.ttl");
+        RdfSyntaxValidationResult result = validator.validateTurtle(file.toString());
+
+        printResult("valid-ontology.ttl", result);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.hasWarnings()).isFalse();
+    }
+
+    @Test
+    @Order(2)
+    void demo_02_errore_puntoMancante() {
+        Path file = resolve("error-missing-dot.ttl");
+        RdfSyntaxValidationResult result = validator.validateTurtle(file.toString());
+
+        printResult("error-missing-dot.ttl", result);
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    @Test
+    @Order(3)
+    void demo_03_errore_prefissoMalformato() {
+        Path file = resolve("error-bad-prefix.ttl");
+        RdfSyntaxValidationResult result = validator.validateTurtle(file.toString());
+
+        printResult("error-bad-prefix.ttl", result);
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    @Test
+    @Order(4)
+    void demo_04_errore_stringaNonChiusa() {
+        Path file = resolve("error-unclosed-string.ttl");
+        RdfSyntaxValidationResult result = validator.validateTurtle(file.toString());
+
+        printResult("error-unclosed-string.ttl", result);
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    @Test
+    @Order(5)
+    void demo_05_errore_iriConSpazi() {
+        Path file = resolve("error-bad-iri.ttl");
+        RdfSyntaxValidationResult result = validator.validateTurtle(file.toString());
+
+        printResult("error-bad-iri.ttl", result);
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    @Test
+    @Order(6)
+    void demo_06_errore_fileNonTurtle() {
+        Path file = resolve("error-garbage.ttl");
+        RdfSyntaxValidationResult result = validator.validateTurtle(file.toString());
+
+        printResult("error-garbage.ttl", result);
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    @Test
+    @Order(7)
+    void demo_07_errore_problemiMultipli() {
+        Path file = resolve("error-multiple-issues.ttl");
+        RdfSyntaxValidationResult result = validator.validateTurtle(file.toString());
+
+        printResult("error-multiple-issues.ttl", result);
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    @Test
+    @Order(8)
+    void demo_08_riepilogoSuTuttiIFile() throws IOException {
+        System.out.println();
+        System.out.println("-".repeat(80));
+        System.out.println("  RIEPILOGO: scansione di tutti i file nella directory demo");
+        System.out.println("-".repeat(80));
+
+        Path dir = resolveDir();
+
+        int valid = 0;
+        int invalid = 0;
+
+        try (Stream<Path> files = Files.list(dir)) {
+            for (Path file : files.filter(f -> f.toString().endsWith(".ttl")).sorted().toList()) {
+                RdfSyntaxValidationResult result = validator.validateTurtle(file.toString());
+                String status = result.isValid() ? "PASS" : "FAIL";
+                String detail = result.isValid()
+                        ? (result.hasWarnings() ? result.getWarnings().size() + " warning(s)" : "OK")
+                        : result.getErrors().size() + " errore/i";
+
+                System.out.printf("  [%s] %-35s %s%n", status, file.getFileName(), detail);
+
+                if (result.isValid()) {
+                    valid++;
+                } else {
+                    invalid++;
+                }
+            }
+        }
+
+        System.out.println();
+        System.out.printf("  Totale: %d file | %d validi | %d con errori bloccanti%n", valid + invalid, valid, invalid);
+        System.out.println("=".repeat(80));
+        System.out.println();
+
+        assertThat(valid).isGreaterThan(0);
+        assertThat(invalid).isGreaterThan(0);
+    }
+
+    // --- utility ---
+
+    private static Path resolveDir() {
+        try {
+            return Paths.get(Objects.requireNonNull(
+                    RdfSyntaxValidatorDemoTest.class.getClassLoader().getResource(SAMPLE_RESOURCE_DIR)).toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Path resolve(String filename) {
+        Path file = resolveDir().resolve(filename);
+        assertThat(file).as("Il file di esempio %s deve esistere", filename).exists();
+        return file;
+    }
+
+    private static void printResult(String filename, RdfSyntaxValidationResult result) {
+        System.out.println("-".repeat(80));
+        System.out.printf("  File: %s%n", filename);
+        System.out.printf("  Esito: %s%n", result.isValid() ? "VALIDO" : "ERRORE BLOCCANTE");
+
+        if (result.hasErrors()) {
+            System.out.println("  Errori:");
+            result.getErrors().forEach(e ->
+                    System.out.printf("    - %s%n", e));
+        }
+        if (result.hasWarnings()) {
+            System.out.println("  Warning:");
+            result.getWarnings().forEach(w ->
+                    System.out.printf("    - %s%n", w));
+        }
+        if (!result.hasErrors() && !result.hasWarnings()) {
+            System.out.println("  Nessun problema rilevato.");
+        }
+        System.out.println();
+    }
+}

--- a/src/test/java/it/gov/innovazione/ndc/harvester/validation/RdfSyntaxValidatorTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/validation/RdfSyntaxValidatorTest.java
@@ -1,0 +1,104 @@
+package it.gov.innovazione.ndc.harvester.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RdfSyntaxValidatorTest {
+
+    private RdfSyntaxValidator validator;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        validator = new RdfSyntaxValidator();
+    }
+
+    @Test
+    void shouldPassForValidTurtle() throws IOException {
+        Path ttlFile = tempDir.resolve("valid.ttl");
+        Files.writeString(ttlFile, """
+                @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+                @prefix dct:  <http://purl.org/dc/terms/> .
+
+                <http://example.org/vocab/1>
+                    a skos:ConceptScheme ;
+                    dct:title "Test Vocabulary"@it .
+                """);
+
+        RdfSyntaxValidationResult result = validator.validateTurtle(ttlFile.toString());
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.hasErrors()).isFalse();
+    }
+
+    @Test
+    void shouldFailForMalformedTurtle() throws IOException {
+        Path ttlFile = tempDir.resolve("malformed.ttl");
+        Files.writeString(ttlFile, """
+                @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+                <http://example.org/vocab/1>
+                    a skos:ConceptScheme
+                    dct:title "Missing dot and prefix"@it .
+                """);
+
+        RdfSyntaxValidationResult result = validator.validateTurtle(ttlFile.toString());
+
+        assertThat(result.hasErrors()).isTrue();
+        assertThat(result.getErrors()).isNotEmpty();
+        assertThat(result.getErrorsSummary()).isNotBlank();
+    }
+
+    @Test
+    void shouldFailForCompletelyInvalidContent() throws IOException {
+        Path ttlFile = tempDir.resolve("garbage.ttl");
+        Files.writeString(ttlFile, "this is not turtle at all { } [ ]");
+
+        RdfSyntaxValidationResult result = validator.validateTurtle(ttlFile.toString());
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    @Test
+    void shouldFailForNonExistentFile() {
+        RdfSyntaxValidationResult result = validator.validateTurtle("/non/existent/file.ttl");
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    @Test
+    void shouldReportLineAndColumnForErrors() throws IOException {
+        Path ttlFile = tempDir.resolve("error_position.ttl");
+        Files.writeString(ttlFile, """
+                @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+                <http://example.org/vocab/1>
+                    a skos:ConceptScheme ;
+                    skos:prefLabel "unclosed string@it .
+                """);
+
+        RdfSyntaxValidationResult result = validator.validateTurtle(ttlFile.toString());
+
+        assertThat(result.hasErrors()).isTrue();
+        assertThat(result.getErrors().get(0).getLine()).isGreaterThan(0);
+    }
+
+    @Test
+    void shouldPassForEmptyButValidTurtle() throws IOException {
+        Path ttlFile = tempDir.resolve("empty.ttl");
+        Files.writeString(ttlFile, "# This is an empty turtle file with only a comment\n");
+
+        RdfSyntaxValidationResult result = validator.validateTurtle(ttlFile.toString());
+
+        assertThat(result.isValid()).isTrue();
+    }
+}

--- a/src/test/java/it/gov/innovazione/ndc/service/ValidationServiceTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/service/ValidationServiceTest.java
@@ -2,6 +2,8 @@ package it.gov.innovazione.ndc.service;
 
 import it.gov.innovazione.ndc.controller.exception.InvalidFileException;
 import it.gov.innovazione.ndc.controller.exception.SemanticAssetGenericErrorException;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidationResult;
+import it.gov.innovazione.ndc.harvester.validation.RdfSyntaxValidator;
 import it.gov.innovazione.ndc.validator.SemanticAssetValidator;
 import it.gov.innovazione.ndc.validator.ValidationResultDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,9 +19,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static it.gov.innovazione.ndc.harvester.SemanticAssetType.CONTROLLED_VOCABULARY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,11 +37,14 @@ class ValidationServiceTest {
     @Mock
     SemanticAssetValidator semanticAssetValidator;
 
+    @Mock
+    RdfSyntaxValidator rdfSyntaxValidator;
+
     private ValidationService validationService;
 
     @BeforeEach
     public void setUp() {
-        validationService = new ValidationService(List.of(semanticAssetValidator));
+        validationService = new ValidationService(List.of(semanticAssetValidator), rdfSyntaxValidator);
     }
 
     @Test
@@ -80,5 +87,30 @@ class ValidationServiceTest {
         ValidationResultDto validationResult = validationService.validate(multipartFile, "controlled vocabulary");
 
         assertEquals(1, validationResult.getErrors().size());
+    }
+
+    @Test
+    void validateSyntaxShouldDelegateToRdfSyntaxValidator() throws Exception {
+        when(multipartFile.getContentType()).thenReturn("text/turtle");
+
+        RdfSyntaxValidationResult expectedResult = RdfSyntaxValidationResult.builder()
+                .error(RdfSyntaxValidationResult.Issue.builder()
+                        .line(3).col(5).message("Bad syntax").build())
+                .build();
+        when(rdfSyntaxValidator.validateTurtle(anyString())).thenReturn(expectedResult);
+
+        RdfSyntaxValidationResult result = validationService.validateSyntax(multipartFile);
+
+        assertThat(result.hasErrors()).isTrue();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getMessage()).isEqualTo("Bad syntax");
+        verify(rdfSyntaxValidator).validateTurtle(anyString());
+    }
+
+    @Test
+    void validateSyntaxShouldRejectNonTurtleContentType() {
+        when(multipartFile.getContentType()).thenReturn("text/plain");
+
+        assertThrows(InvalidFileException.class, () -> validationService.validateSyntax(multipartFile));
     }
 }

--- a/src/test/resources/demo-sample-ttl/error-bad-iri.ttl
+++ b/src/test/resources/demo-sample-ttl/error-bad-iri.ttl
@@ -1,0 +1,6 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://w3id.org/italia/onto/Bad IRI With Spaces>
+    a owl:Ontology ;
+    dct:title "IRI con spazi - non valido secondo RFC 3987"@it .

--- a/src/test/resources/demo-sample-ttl/error-bad-prefix.ttl
+++ b/src/test/resources/demo-sample-ttl/error-bad-prefix.ttl
@@ -1,0 +1,6 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix dct   <http://purl.org/dc/terms/> .
+
+<https://w3id.org/italia/onto/BadPrefix>
+    a owl:Ontology ;
+    dct:title "Prefisso malformato - mancano i due punti"@it .

--- a/src/test/resources/demo-sample-ttl/error-garbage.ttl
+++ b/src/test/resources/demo-sample-ttl/error-garbage.ttl
@@ -1,0 +1,3 @@
+Questo file non e' assolutamente Turtle.
+E' solo testo libero { con qualche } parentesi [graffa] random.
+Non contiene nessun triple RDF valido.

--- a/src/test/resources/demo-sample-ttl/error-missing-dot.ttl
+++ b/src/test/resources/demo-sample-ttl/error-missing-dot.ttl
@@ -1,0 +1,9 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<https://w3id.org/italia/onto/Broken>
+    a owl:Ontology ;
+    dct:title "Ontologia con punto mancante"@it
+    dct:description "Manca il punto e virgola dopo title"@it .

--- a/src/test/resources/demo-sample-ttl/error-multiple-issues.ttl
+++ b/src/test/resources/demo-sample-ttl/error-multiple-issues.ttl
@@ -1,0 +1,12 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<https://w3id.org/italia/onto/MultiError>
+    a owl:Ontology ;
+    dct:title "Primo errore: virgola mancante"@it
+    dct:description "Secondo errore segue"@it ;
+    dct:rightsHolder [
+        a foaf:Agent
+        foaf:name "Agenzia"@it
+    ] .

--- a/src/test/resources/demo-sample-ttl/error-unclosed-string.ttl
+++ b/src/test/resources/demo-sample-ttl/error-unclosed-string.ttl
@@ -1,0 +1,7 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://w3id.org/italia/onto/UnclosedString>
+    a owl:Ontology ;
+    dct:title "Stringa non chiusa@it ;
+    dct:description "Questa riga non verra' mai raggiunta"@it .

--- a/src/test/resources/demo-sample-ttl/valid-ontology.ttl
+++ b/src/test/resources/demo-sample-ttl/valid-ontology.ttl
@@ -1,0 +1,31 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+<https://w3id.org/italia/onto/Example>
+    a owl:Ontology ;
+    dct:title "Ontologia di Esempio"@it , "Example Ontology"@en ;
+    dct:description "Un'ontologia valida usata per la demo GOV-QUAL"@it ;
+    dct:modified "2026-03-01"^^xsd:date ;
+    dct:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/IRREG> ;
+    dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
+    dct:rightsHolder <https://w3id.org/italia/data/organization/support-unit/ustat-mef> ;
+    owl:versionInfo "0.1" ;
+    dct:issued "2026-01-15"^^xsd:date ;
+    dct:language <http://publications.europa.eu/resource/authority/language/ITA> ;
+    dcat:contactPoint <https://w3id.org/italia/data/contact-point/example> .
+
+<https://w3id.org/italia/data/organization/support-unit/ustat-mef>
+    a foaf:Agent ;
+    dct:identifier "ustat-mef" ;
+    foaf:name "Ufficio Statistica MEF"@it .
+
+<https://w3id.org/italia/data/contact-point/example>
+    a vcard:Kind ;
+    vcard:hasEmail <mailto:info@example.gov.it> .


### PR DESCRIPTION
## Summary

- **Validazione sintattica pre-harvesting**: integra Apache Jena RIOT per verificare la sintassi Turtle dei file `.ttl` prima dell'ingestion, bloccando gli asset malformati senza interrompere il resto dell'harvesting
- **Nuovo endpoint REST `POST /validate/syntax`**: permette la validazione sintattica standalone di un file Turtle, restituendo errori e warning strutturati (riga, colonna, messaggio) con flag `valid`
- **Report strutturato**: ogni problema riporta `line`, `col` e `message` leggibile, separando errori bloccanti da warning non bloccanti

## Dettaglio modifiche

### Nuovi file
- `RdfSyntaxValidator` — validatore core con `RDFParser` + `ErrorHandler` custom, parse a `sinkNull()` (zero allocazione Model)
- `RdfSyntaxValidationResult` — DTO con liste errors/warnings e helper methods
- `RdfSyntaxValidatorTest` — 6 unit test (file valido, malformato, garbage, inesistente, posizioni errore, file vuoto)
- `RdfSyntaxValidatorDemoTest` — test demo visuale con output formattato su 7 file TTL di esempio
- 7 file TTL di esempio in `src/test/resources/demo-sample-ttl/`

### File modificati
- `BaseSemanticAssetPathProcessor` — aggiunta validazione pre-`loadModel()` con logging e `SinglePathProcessingException(fatal=false)` se la sintassi fallisce
- `OntologyPathProcessor`, `SchemaPathProcessor`, `ControlledVocabularyPathProcessor` — propagazione del nuovo parametro `RdfSyntaxValidator`
- `ValidationController` — nuovo endpoint `POST /validate/syntax`
- `ValidationService` — nuovo metodo `validateSyntax()` con temp file
- `HarvesterStage` — aggiunto stage `SYNTAX_VALIDATION`
- Test aggiornati per tutti i path processor e per `ValidationService`

## Test plan

- [x] Unit test `RdfSyntaxValidatorTest` (6 casi)
- [x] Unit test `SemanticAssetPathProcessorTest` (2 nuovi casi: errore bloccante, warning non bloccante)
- [x] Unit test `ValidationServiceTest` (2 nuovi casi: delega al validator, reject non-Turtle)
- [x] Test demo `RdfSyntaxValidatorDemoTest` (8 casi con output visuale)
- [ ] Test manuale endpoint con curl/Postman (vedi `backlog/GOV-QUAL/demo/DEMO-API.md`)